### PR TITLE
Detect Lua 5.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,7 +102,7 @@ AC_COMPILE_IFELSE(
 AS_IF([test x"$LUA52_FROM_SOURCE" = xyes], [
     LUA_INCLUDE='-I$(top_srcdir)/fityk/lua52/src'
   ], [
-    AX_PROG_LUA(5.1, 5.5)
+    AX_PROG_LUA(5.1, 5.6)
     AX_LUA_HEADERS
     AX_LUA_LIBS
 ])


### PR DESCRIPTION
Lua 5.5 is now the latest upstream version, no code changes appear necessary to fityk to support it, this simply changes the configure.ac check to widen the supported range of versions.