### PR TITLE
Add files created during build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.o
 *.Po
 *.Plo
+*.lo
+*.la
 cscope.out
 tags
 Makefile.in
@@ -42,3 +44,12 @@ stamp-h1
 config.h
 config.log
 config.status
+.dirstamp
+cfityk
+fityk/.libs/libfityk.lai
+fityk/.libs/libfityk.so
+fityk/.libs/libfityk.so.4
+fityk/.libs/libfityk.so.4.0.0
+wxgui/fityk
+wxgui/libceria.a
+wxgui/.libs/fityk

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.bak
 *.pyc
 *.o
+*.Po
+*.Plo
 cscope.out
 tags
 Makefile.in
@@ -34,3 +36,9 @@ fityk/cmpfit/*.patch
 *-build-*/
 fityk-?.?.?-setup.exe
 fityk-?.?.?.tar.bz2
+fityk.iss
+libtool
+stamp-h1
+config.h
+config.log
+config.status


### PR DESCRIPTION
Running `./configure` and `make` generates several files that are not currently ignored by Git. This PR adds those files to `.gitignore`.